### PR TITLE
[#4] Removing mrt_cmake_modules and lanelet2 from build_depends.repos.

### DIFF
--- a/.github/workflows/cuda-ci.yaml
+++ b/.github/workflows/cuda-ci.yaml
@@ -21,7 +21,7 @@ jobs:
       env:
         VCS_FILE: build_depends.repos
         ROS_DISTRO: melodic
-      options: --user 1001
+      options: --user root
 
     steps:
 
@@ -33,7 +33,7 @@ jobs:
         mkdir -p src_tmp/ && mv `find -maxdepth 1 -not -name . -not -name src_tmp -not -name $VCS_FILE` src_tmp/ && mv src_tmp/ src/
         vcs validate < $VCS_FILE
         vcs import src/ < $VCS_FILE
-        rosdep update
+        rosdep update && apt-get update -qqq
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
         mkdir -p depends_ws/src
         mv src/depends depends_ws/src

--- a/.github/workflows/native-ci.yaml
+++ b/.github/workflows/native-ci.yaml
@@ -33,7 +33,7 @@ jobs:
         mkdir -p src_tmp/ && mv `find -maxdepth 1 -not -name . -not -name src_tmp -not -name $VCS_FILE` src_tmp/ && mv src_tmp/ src/
         vcs validate < $VCS_FILE
         vcs import src/ < $VCS_FILE
-        rosdep update
+        rosdep update && apt-get update -qqq
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
         mkdir -p depends_ws/src
         mv src/depends depends_ws/src

--- a/.github/workflows/native-ci.yaml
+++ b/.github/workflows/native-ci.yaml
@@ -21,7 +21,7 @@ jobs:
       env:
         VCS_FILE: build_depends.repos
         ROS_DISTRO: melodic
-      options: --user 1001
+      options: --user root
 
     steps:
 

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,11 +3,3 @@ repositories:
     type: git
     url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
     version: master
-  depends/vendor/lanelet2:
-    type: git
-    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git
-    version: d13cf9c86b9f01821a7242ef6652c0daed5a7d84
-  depends/vendor/mrt_cmake_modules:
-    type: git
-    url: https://github.com/KIT-MRT/mrt_cmake_modules.git
-    version: 9ddefc00303983b8d84fc2e050a2c568a34d0ecd


### PR DESCRIPTION
## New feature implementation
See description.

### Implemented feature
Removed from `build_depends.repos`. Will fix cross-CI on Docker repo.