### PR TITLE
Feature/op planner close path

### DIFF
--- a/op_planner/CMakeLists.txt
+++ b/op_planner/CMakeLists.txt
@@ -74,3 +74,9 @@ install(TARGETS op_planner
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  catkin_add_gtest(test-op_planner test/src/test_BuildPlanningSearchTreeV2.cpp)
+  target_link_libraries(test-op_planner ${catkin_LIBRARIES} ${PROJECT_NAME})
+endif()

--- a/op_planner/include/op_planner/PlannerH.h
+++ b/op_planner/include/op_planner/PlannerH.h
@@ -34,7 +34,8 @@ public:
 
   double PlanUsingDP(const WayPoint& carPos,const WayPoint& goalPos,
       const double& maxPlanningDistance, const bool bEnableLaneChange, const std::vector<int>& globalPath,
-      RoadNetwork& map, std::vector<std::vector<WayPoint> >& paths, std::vector<WayPoint*>* all_cell_to_delete = 0);
+      RoadNetwork& map, std::vector<std::vector<WayPoint> >& paths, std::vector<WayPoint*>* all_cell_to_delete = 0,
+      double fallback_min_goal_distance_th = 0.0);
 
    double PlanUsingDPRandom(const WayPoint& start,
         const double& maxPlanningDistance,

--- a/op_planner/include/op_planner/PlanningHelpers.h
+++ b/op_planner/include/op_planner/PlanningHelpers.h
@@ -125,7 +125,8 @@ public:
       const WayPoint& goalPos,
       const std::vector<int>& globalPath, const double& DistanceLimit,
       const bool& bEnableLaneChange,
-      std::vector<WayPoint*>& all_cells_to_delete );
+      std::vector<WayPoint*>& all_cells_to_delete,
+      double fallback_min_goal_distance_th = 0.0 );
 
   static WayPoint* BuildPlanningSearchTreeStraight(WayPoint* pStart,
       const double& DistanceLimit,
@@ -142,6 +143,8 @@ public:
   static WayPoint* CheckLaneExits(const std::vector<WayPoint*>& nodes, const Lane* pL);
 
   static WayPoint* CheckNodeExits(const std::vector<WayPoint*>& nodes, const WayPoint* pL);
+
+  static int FindNodeIndex(const std::vector<WayPoint*>& nodes, const WayPoint* p);
 
   static WayPoint* CreateLaneHeadCell(Lane* pLane, WayPoint* pLeft, WayPoint* pRight,
       WayPoint* pBack);

--- a/op_planner/src/PlannerH.cpp
+++ b/op_planner/src/PlannerH.cpp
@@ -137,7 +137,9 @@ double PlannerH::PlanUsingDP(const WayPoint& start,
     const bool bEnableLaneChange,
     const std::vector<int>& globalPath,
     RoadNetwork& map,
-    std::vector<std::vector<WayPoint> >& paths, vector<WayPoint*>* all_cell_to_delete)
+    std::vector<std::vector<WayPoint> >& paths,
+    vector<WayPoint*>* all_cell_to_delete,
+    double fallback_min_goal_distance_th)
 {
   PlannerHNS::WayPoint* pStart = PlannerHNS::MappingHelpers::GetClosestWaypointFromMap(start, map);
   PlannerHNS::WayPoint* pGoal = PlannerHNS::MappingHelpers::GetClosestWaypointFromMap(goalPos, map);
@@ -197,9 +199,15 @@ double PlannerH::PlanUsingDP(const WayPoint& start,
   char bPlan = 'A';
 
   if(all_cell_to_delete)
-    pLaneCell =  PlanningHelpers::BuildPlanningSearchTreeV2(pStart, *pGoal, globalPath, maxPlanningDistance,bEnableLaneChange, *all_cell_to_delete);
+    pLaneCell =  PlanningHelpers::BuildPlanningSearchTreeV2(pStart,
+                                      *pGoal, globalPath, maxPlanningDistance,
+                                      bEnableLaneChange, *all_cell_to_delete,
+                                      fallback_min_goal_distance_th);
   else
-    pLaneCell =  PlanningHelpers::BuildPlanningSearchTreeV2(pStart, *pGoal, globalPath, maxPlanningDistance,bEnableLaneChange, local_cell_to_delete);
+    pLaneCell =  PlanningHelpers::BuildPlanningSearchTreeV2(pStart,
+                                      *pGoal, globalPath, maxPlanningDistance,
+                                      bEnableLaneChange, local_cell_to_delete,
+                                      fallback_min_goal_distance_th);
 
   if(!pLaneCell)
   {

--- a/op_planner/src/PlannerH.cpp
+++ b/op_planner/src/PlannerH.cpp
@@ -83,7 +83,11 @@ double PlannerH::PlanUsingDPRandom(const WayPoint& start,
   }
 
   RelativeInfo start_info;
-  PlanningHelpers::GetRelativeInfo(pStart->pLane->points, start, start_info);
+  if(!PlanningHelpers::GetRelativeInfo(pStart->pLane->points, start, start_info))
+  {
+    cout << endl << "Error: PlannerH -> GetRelativeInfo for start failed";
+    return 0;
+  }
 
   if(start_info.perp_distance > START_POINT_MAX_DISTANCE)
   {
@@ -160,8 +164,15 @@ double PlannerH::PlanUsingDP(const WayPoint& start,
   }
 
   RelativeInfo start_info, goal_info;
-  PlanningHelpers::GetRelativeInfo(pStart->pLane->points, start, start_info);
-  PlanningHelpers::GetRelativeInfo(pGoal->pLane->points, goalPos, goal_info);
+  if(!PlanningHelpers::GetRelativeInfo(pStart->pLane->points, start, start_info))
+  {
+    cout << endl << "Error: PlannerH -> GetRelativeInfo for start failed";
+    return 0;
+  }
+  if(!PlanningHelpers::GetRelativeInfo(pGoal->pLane->points, goalPos, goal_info)) {
+    cout << endl << "Error: PlannerH -> GetRelativeInfo for goal failed";
+    return 0;
+  }
 
   vector<WayPoint> start_path, goal_path;
 

--- a/op_planner/src/PlanningHelpers.cpp
+++ b/op_planner/src/PlanningHelpers.cpp
@@ -1954,7 +1954,7 @@ WayPoint* PlanningHelpers::BuildPlanningSearchTreeV2(WayPoint* pStart,
     vector<WayPoint*>& all_cells_to_delete,
     double fallback_min_goal_distance_th)
 {
-  if(!pStart) return NULL;
+  if(!pStart) return nullptr;
 
   vector<pair<WayPoint*, WayPoint*> >nextLeafToTrace;
 
@@ -2136,7 +2136,7 @@ WayPoint* PlanningHelpers::BuildPlanningSearchTreeStraight(WayPoint* pStart,
     const double& DistanceLimit,
     vector<WayPoint*>& all_cells_to_delete)
 {
-  if(!pStart) return NULL;
+  if(!pStart) return nullptr;
 
   vector<pair<WayPoint*, WayPoint*> >nextLeafToTrace;
 
@@ -2476,7 +2476,7 @@ WayPoint* PlanningHelpers::CreateLaneHeadCell(Lane* pLane, WayPoint* pLeft, WayP
 double PlanningHelpers::GetLanePoints(Lane* l, const WayPoint& prevWayPointIndex,
     const double& minDistance , const double& prevCost, vector<WayPoint>& points)
 {
-  if(l == NULL || minDistance<=0) return 0;
+  if(l == nullptr || minDistance<=0) return 0;
 
   int index = 0;
   WayPoint  p1, p2;
@@ -2604,7 +2604,7 @@ void PlanningHelpers::ExtractPlanAlernatives(const std::vector<WayPoint>& single
 void PlanningHelpers::TraversePathTreeBackwards(WayPoint* pHead, WayPoint* pStartWP,const vector<int>& globalPathIds,
     vector<WayPoint>& localPath, std::vector<std::vector<WayPoint> >& localPaths)
 {
-  if(pHead != NULL && pHead->id != pStartWP->id)
+  if(pHead != nullptr && pHead->id != pStartWP->id)
   {
     if(pHead->pBacks.size()>0)
     {

--- a/op_planner/test/src/test_BuildPlanningSearchTreeV2.cpp
+++ b/op_planner/test/src/test_BuildPlanningSearchTreeV2.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2020 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op_planner/PlanningHelpers.h"
+
+using namespace PlannerHNS;
+
+#include <ros/ros.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+class TestSuite:
+  public ::testing::Test
+{
+public:
+  TestSuite() {}
+};
+
+TEST(TestSuite, TestNoPathFound)
+{
+  WayPoint start_position;
+  WayPoint intermediate_position_1;
+  WayPoint intermediate_position_2;
+  WayPoint intermediate_position_3;
+  WayPoint goal_position;
+  WayPoint* result;
+  std::vector<int> global_path;
+  double distance_limit = 34;
+  bool enable_line_change = false;
+  std::vector<WayPoint*> all_cell_to_delete;
+  double fallback_min_goal_distance_th = 0;
+
+  start_position.pos.x = 0;
+  start_position.pos.y = 0;
+  start_position.pos.z = 0;
+  start_position.pos.a = 0;
+  start_position.pFronts.push_back(&intermediate_position_1);
+
+  intermediate_position_1.pos.x = 10;
+  intermediate_position_1.pos.y = 0;
+  intermediate_position_1.pos.z = 0;
+  intermediate_position_1.pos.a = 0;
+  intermediate_position_1.pFronts.push_back(&intermediate_position_2);
+  intermediate_position_1.pBacks.push_back(&start_position);
+  intermediate_position_1.id = 1;
+
+  intermediate_position_2.pos.x = 20;
+  intermediate_position_2.pos.y = 0;
+  intermediate_position_2.pos.z = 0;
+  intermediate_position_2.pos.a = 0;
+  intermediate_position_2.pFronts.push_back(&intermediate_position_3);
+  intermediate_position_2.pBacks.push_back(&intermediate_position_1);
+  intermediate_position_2.id = 2;
+
+  intermediate_position_3.pos.x = 30;
+  intermediate_position_3.pos.y = 0;
+  intermediate_position_3.pos.z = 0;
+  intermediate_position_3.pos.a = 0;
+  intermediate_position_3.pBacks.push_back(&intermediate_position_2);
+  intermediate_position_3.id = 3;
+
+  goal_position.pos.x = 34;
+  goal_position.pos.y = 0;
+  goal_position.pos.z = 0;
+  goal_position.pos.a = 0;
+
+  result = PlanningHelpers::BuildPlanningSearchTreeV2(
+    &start_position,
+    goal_position,
+    global_path,
+    distance_limit,
+    enable_line_change,
+    all_cell_to_delete,
+    fallback_min_goal_distance_th);
+
+  // Assert no path is found
+  ASSERT_TRUE(result == 0);
+}
+
+TEST(TestSuite, TestPathFound)
+{
+  WayPoint start_position;
+  WayPoint intermediate_position_1;
+  WayPoint intermediate_position_2;
+  WayPoint intermediate_position_3;
+  WayPoint goal_position;
+  WayPoint* result;
+  std::vector<int> global_path;
+  double distance_limit = 34;
+  bool enable_line_change = false;
+  std::vector<WayPoint*> all_cell_to_delete;
+  double fallback_min_goal_distance_th = 0;
+
+  start_position.pos.x = 0;
+  start_position.pos.y = 0;
+  start_position.pos.z = 0;
+  start_position.pos.a = 0;
+  start_position.pFronts.push_back(&intermediate_position_1);
+
+  intermediate_position_1.pos.x = 10;
+  intermediate_position_1.pos.y = 0;
+  intermediate_position_1.pos.z = 0;
+  intermediate_position_1.pos.a = 0;
+  intermediate_position_1.pFronts.push_back(&intermediate_position_2);
+  intermediate_position_1.pBacks.push_back(&start_position);
+  intermediate_position_1.id = 1;
+
+  intermediate_position_2.pos.x = 20;
+  intermediate_position_2.pos.y = 0;
+  intermediate_position_2.pos.z = 0;
+  intermediate_position_2.pos.a = 0;
+  intermediate_position_2.pFronts.push_back(&intermediate_position_3);
+  intermediate_position_2.pBacks.push_back(&intermediate_position_1);
+  intermediate_position_2.id = 2;
+
+  intermediate_position_3.pos.x = 34;
+  intermediate_position_3.pos.y = 0;
+  intermediate_position_3.pos.z = 0;
+  intermediate_position_3.pos.a = 0;
+  intermediate_position_3.pBacks.push_back(&intermediate_position_2);
+  intermediate_position_3.id = 3;
+
+  goal_position.pos.x = 34;
+  goal_position.pos.y = 0;
+  goal_position.pos.z = 0;
+  goal_position.pos.a = 0;
+
+  result = PlanningHelpers::BuildPlanningSearchTreeV2(
+    &start_position,
+    goal_position,
+    global_path,
+    distance_limit,
+    enable_line_change,
+    all_cell_to_delete,
+    fallback_min_goal_distance_th);
+
+  // Assert a path is found
+  ASSERT_TRUE(result != 0);
+  ASSERT_DOUBLE_EQ(result->pos.x, 34);
+  ASSERT_DOUBLE_EQ(result->pos.y, 0);
+  ASSERT_DOUBLE_EQ(result->pos.z, 0);
+  ASSERT_DOUBLE_EQ(result->pos.a, 0);
+}
+
+TEST(TestSuite, TestPathCloseEnough)
+{
+  WayPoint start_position;
+  WayPoint intermediate_position_1;
+  WayPoint intermediate_position_2;
+  WayPoint intermediate_position_3;
+  WayPoint goal_position;
+  WayPoint* result;
+  std::vector<int> global_path;
+  double distance_limit = 34;
+  bool enable_line_change = false;
+  std::vector<WayPoint*> all_cell_to_delete;
+  double fallback_min_goal_distance_th = 5;
+
+  start_position.pos.x = 0;
+  start_position.pos.y = 0;
+  start_position.pos.z = 0;
+  start_position.pos.a = 0;
+  start_position.pFronts.push_back(&intermediate_position_1);
+
+  intermediate_position_1.pos.x = 10;
+  intermediate_position_1.pos.y = 0;
+  intermediate_position_1.pos.z = 0;
+  intermediate_position_1.pos.a = 0;
+  intermediate_position_1.pFronts.push_back(&intermediate_position_2);
+  intermediate_position_1.pBacks.push_back(&start_position);
+  intermediate_position_1.id = 1;
+
+  intermediate_position_2.pos.x = 20;
+  intermediate_position_2.pos.y = 0;
+  intermediate_position_2.pos.z = 0;
+  intermediate_position_2.pos.a = 0;
+  intermediate_position_2.pFronts.push_back(&intermediate_position_3);
+  intermediate_position_2.pBacks.push_back(&intermediate_position_1);
+  intermediate_position_2.id = 2;
+
+  intermediate_position_3.pos.x = 30;
+  intermediate_position_3.pos.y = 0;
+  intermediate_position_3.pos.z = 0;
+  intermediate_position_3.pos.a = 0;
+  intermediate_position_3.pBacks.push_back(&intermediate_position_2);
+  intermediate_position_3.id = 3;
+
+  goal_position.pos.x = 34;
+  goal_position.pos.y = 0;
+  goal_position.pos.z = 0;
+  goal_position.pos.a = 0;
+
+  result = PlanningHelpers::BuildPlanningSearchTreeV2(
+    &start_position,
+    goal_position,
+    global_path,
+    distance_limit,
+    enable_line_change,
+    all_cell_to_delete,
+    fallback_min_goal_distance_th);
+
+  // Assert a close enough path is found
+  ASSERT_TRUE(result != 0);
+  ASSERT_DOUBLE_EQ(result->pos.x, 30);
+  ASSERT_DOUBLE_EQ(result->pos.y, 0);
+  ASSERT_DOUBLE_EQ(result->pos.z, 0);
+  ASSERT_DOUBLE_EQ(result->pos.a, 0);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "TestNode");
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Bug fix

### Fixed bug
- Add additional checks in op_planner
- Use nullptr instead of NULL in op_planner

### Fix applied
- Add additional checks for GetRelativeInfo calls to return earlier when an error condition is found.
- Change the NULL macro to nullptr

## New feature implementation

### Implemented feature
Allow the op_planner to find a close enough waypoint for the goal.
The aim is to create a "two objective" target, the priority is to find a good waypoint to the goal, if it can't be satisfied, then it
fall-back to the second objective that is finding the closest waypoint below a threshold.
This feature can be enabled/disabled depending on the passed arguments and by default is disabled.

### Implementation description
During the search for the waypoint closest to the goal, also the minimum distance waypoint is saved. If the search can't be satisfied, then if the minimum distance waypoint is below the defined threshold, it is used as valid path.
