### PR TITLE
libwaypoint_follower: Fix MinIDSearch return type

### DIFF
--- a/libwaypoint_follower/src/libwaypoint_follower.cpp
+++ b/libwaypoint_follower/src/libwaypoint_follower.cpp
@@ -229,7 +229,7 @@ public:
       val_min_ = v;
     }
   }
-  const double result() const
+  const int result() const
   {
     return idx_min_;
   }


### PR DESCRIPTION
The return type of MinIDSearch::result() should be int instead of double.