### PR TITLE
libwaypoint_follower: Fix getClosestWaypoint, remove logging from library functions

### DIFF
--- a/libwaypoint_follower/src/libwaypoint_follower.cpp
+++ b/libwaypoint_follower/src/libwaypoint_follower.cpp
@@ -162,7 +162,6 @@ double getRelativeAngle(geometry_msgs::Pose waypoint_pose, geometry_msgs::Pose v
   relative_waypoint_v.normalize();
   tf::Vector3 relative_pose_v(1, 0, 0);
   double angle = relative_pose_v.angle(relative_waypoint_v) * 180 / M_PI;
-  // ROS_INFO("angle : %lf",angle);
 
   return angle;
 }
@@ -243,7 +242,9 @@ public:
 int getClosestWaypoint(const autoware_msgs::Lane &current_path, geometry_msgs::Pose current_pose)
 {
   if (current_path.waypoints.size() < 2 || getLaneDirection(current_path) == LaneDirection::Error)
+  {
     return -1;
+  }
 
   WayPoints wp;
   wp.setPath(current_path);
@@ -252,7 +253,7 @@ int getClosestWaypoint(const autoware_msgs::Lane &current_path, geometry_msgs::P
   double search_distance = 5.0;
   double angle_threshold = 90;
   MinIDSearch cand_idx, not_cand_idx;
-  for (int i = 1; i < wp.getSize(); i++)
+  for (int i = 0; i < wp.getSize(); i++)
   {
     if (!wp.inDrivingDirection(i, current_pose))
       continue;
@@ -263,10 +264,6 @@ int getClosestWaypoint(const autoware_msgs::Lane &current_path, geometry_msgs::P
     if (getRelativeAngle(wp.getWaypointPose(i), current_pose) > angle_threshold)
       continue;
     cand_idx.update(i, distance);
-  }
-  if (!cand_idx.isOK())
-  {
-    ROS_INFO("no candidate. search closest waypoint from all waypoints...");
   }
   return (!cand_idx.isOK()) ? not_cand_idx.result() : cand_idx.result();
 }
@@ -282,7 +279,6 @@ bool getLinearEquation(geometry_msgs::Point start, geometry_msgs::Point end, dou
 
   if (sub_x < error && sub_y < error)
   {
-    ROS_INFO("two points are the same point!!");
     return false;
   }
 
@@ -519,4 +515,3 @@ geometry_msgs::Point transformToRelativeCoordinate3D(const geometry_msgs::Point 
   geometry_msgs::Point transformed_p = tf2::toMsg(transformed_v);
   return transformed_p;
 }
-

--- a/libwaypoint_follower/test/src/test_libwaypoint_follower.cpp
+++ b/libwaypoint_follower/test/src/test_libwaypoint_follower.cpp
@@ -188,7 +188,7 @@ TEST_F(LibWaypointFollowerTestSuite, getClosestWaypoint)
   dataset["(no_point_path)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, 0.0, 0, valid_pose), -1);
   dataset["(valid_forward)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, -0.5, 100, valid_pose), 1);
   dataset["(valid_backward)"] = std::make_pair(ClosestCheckDataSet(-1, -5.0, -1.5, 100, valid_pose), 2);
-  dataset["(over_distance)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, 6.0, 100, valid_pose), 1);
+  dataset["(over_distance)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, 6.0, 100, valid_pose), 0);
   dataset["(opposite_lane)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, -0.5, 100, invalid_pose), 1);
   dataset["(pass_endpoint)"] = std::make_pair(ClosestCheckDataSet(1, 5.0, -100.0, 100, valid_pose), -1);
 


### PR DESCRIPTION
Fixed a small bug where the getClosestWaypoint function would start at index 1 instead of 0, which caused it to miss the first point which could actually be the closest point.

Also removed logging from library functions, it should be up to the caller of the function to check return values and produce appropriate log messages according to the use case.