### PR TITLE
Adding tvm_vendor to build_depends.repos.

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,3 +3,7 @@ repositories:
     type: git
     url: https://github.com/Autoware-AI/messages.git
     version: master
+  depends/tvm_vendor:
+    type: git
+    url: https://github.com/autowarefoundation/tvm_vendor.git
+    version: main


### PR DESCRIPTION
## New feature implementation

### Implemented feature
Added tvm_vendor to build_depends.repos as a dependency for #14.

@LucaFos or @ambroise-arm - please review. CI should tell us if there are any significant problems.